### PR TITLE
fix error on profile switch

### DIFF
--- a/ElvUI_HealerOnlyPower/Core.lua
+++ b/ElvUI_HealerOnlyPower/Core.lua
@@ -115,6 +115,7 @@ function module:UpdateOptions(group)
 	elseif not module.db.enable then
 		if module:IsHooked(UF, 'Update_RaidFrames') then
 			-- print('|cff00FF98HOP:|r Disabled')
+			module:Unhook(UF, 'Update_PartyFrames')
 			module:Unhook(UF, 'Update_RaidFrames')
 			module:UnregisterEvent('PLAYER_ROLES_ASSIGNED')
 		end


### PR DESCRIPTION
Switching profiles errors with:

```
1x ...lvUI_Libraries/Core/Ace3/AceHook-3.0-9/AceHook-3.0.lua:180: Attempting to rehook already active hook Update_PartyFrames.
[string "=[C]"]: ?
[string "@ElvUI_Libraries/Core/Ace3/AceHook-3.0-9/AceHook-3.0.lua"]:180: in function <...lvUI_Libraries/Core/Ace3/AceHook-3.0/AceHook-3.0.lua:118>
[string "@ElvUI_Libraries/Core/Ace3/AceHook-3.0-9/AceHook-3.0.lua"]:340: in function `SecureHook'
[string "@ElvUI_HealerOnlyPower/Core.lua"]:111: in function <ElvUI_HealerOnlyPower/Core.lua:104>
[string "=[C]"]: ?
[string "=[C]"]: ?
[string "=[C]"]: ?
[string "=[C]"]: in function `UpdateAll'
[string "@ElvUI/Core/General/Core.lua"]:1577: in function <ElvUI/Core/General/Core.lua:1565>

Locals:
(*temporary) = "Attempting to rehook already active hook Update_PartyFrames."
```

due to a missing unhook.